### PR TITLE
Update BuildFHSUserEnv to BuildFHSEnv in preparation for 25.11

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
         '';
       };
 
-      godot-bin = pkgs.buildFHSUserEnv {
+      godot-bin = pkgs.buildFHSEnv {
         name = "godot";
         targetPkgs = pkgs: buildInputs ++ [godot-unwrapped];
         runScript = "godot";


### PR DESCRIPTION
Removes a warning when entering a dev shell as BuildFHSUserEnv is being renamed to BuildFHSEnv